### PR TITLE
Possible oversight in launcher code

### DIFF
--- a/bin/launcher
+++ b/bin/launcher
@@ -19,7 +19,7 @@ options = {
 }
 
 config = ENV["APP_CONFIG"] || File.join(ROOT, "config", "config.yml")
-if File.file?(ENV["APP_CONFIG"])
+if File.file?(config)
   options = options.merge(Hash[YAML.load_file(config).map { |k, v| [k.to_sym, v] }])
 end
 


### PR DESCRIPTION
Hello Yuu!

I'm working through the programming exercise and found the launcher code disregards the null check on line 21 and instead requires a filepath to be present in `ENV["APP_CONFIG"]`.

Based on the commit history this change was very recent and might not have been vetted all the way, but could possibly be a part of the challenge! 

If so please let me know and disregard the Pull Request.

Thanks,
Brandon Crisp
